### PR TITLE
Hive shaded JAR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
     "org.apache.hive" % "hive-cli" % hiveVersion % "test" excludeAll(
       ExclusionRule(organization = "org.apache.spark"),
       ExclusionRule(organization = "org.apache.parquet"),
-      ExclusionRule("ch.qos.logback", "logback-class ic"),
+      ExclusionRule("ch.qos.logback", "logback-classic"),
       ExclusionRule("org.pentaho", "pentaho-aggdesigner-algorithm"),
       ExclusionRule(organization = "com.google.protobuf")
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,6 @@ lazy val hive = (project in file("hive")) dependsOn(standalone) settings (
   )
 )
 
-
 lazy val hiveMR = (project in file("hive-mr")) dependsOn(hive % "test->test") settings (
   name := "hive-mr",
   commonSettings,


### PR DESCRIPTION
Process:
- added this plugin as a helper: https://github.com/sbt/sbt-dependency-graph
- looked at `hive` dependencies using `dependencyList` (see below)
- looked at `standalone` dependencies using `dependencyList` (see below)
- followed sbt assembly plugin example (https://github.com/sbt/sbt-assembly) and referred to `delta-io:connectors/master build.sbt`
- to `hive` project in `build.sbt`, added the relevant (that I thought were applicable) `Packages to exclude from shading because they are not happy when shaded` shade rules
- to `hive` project in `build.sbt`, added the  relevant (that I thought were applicable) `Shade everything else` shade rules
- ran `assembly` command to generate the JAR

Questions:
- How do I know test that the generated jar is correct?
- How do I know when/what to shade?
- How do I verify that dependencies were properly shaded?
- How do I know if there is a dependency merge conflict that needs an appropriate merge strategy?

Hive deps: (exact same as standalone deps except for `io.delta:hive-delta_2.12:0.2.0`)
```
com.chuusai:shapeless_2.12:2.3.3
com.fasterxml.jackson.core:jackson-annotations:2.6.7
com.fasterxml.jackson.core:jackson-core:2.6.7
com.fasterxml.jackson.core:jackson-databind:2.6.7
com.fasterxml.jackson.module:jackson-module-paranamer:2.7.9
com.fasterxml.jackson.module:jackson-module-scala_2.12:2.6.7.1
com.github.mjakubowski84:parquet4s-core_2.12:1.2.1
com.thoughtworks.paranamer:paranamer:2.8
commons-codec:commons-codec:1.10
commons-pool:commons-pool:1.6
io.delta:hive-delta_2.12:0.2.0
io.delta:standalone_2.12:0.2.0
org.apache.parquet:parquet-column:1.10.1
org.apache.parquet:parquet-common:1.10.1
org.apache.parquet:parquet-encoding:1.10.1
org.apache.parquet:parquet-format:2.4.0
org.apache.parquet:parquet-hadoop:1.10.1
org.apache.parquet:parquet-jackson:1.10.1
org.codehaus.jackson:jackson-core-asl:1.9.13
org.codehaus.jackson:jackson-mapper-asl:1.9.13
org.json4s:json4s-ast_2.12:3.5.3
org.json4s:json4s-core_2.12:3.5.3
org.json4s:json4s-jackson_2.12:3.5.3
org.json4s:json4s-scalap_2.12:3.5.3
org.scala-lang:scala-reflect:2.12.8
org.scala-lang.modules:scala-collection-compat_2.12:2.1.6
org.scala-lang.modules:scala-xml_2.12:1.0.6
org.slf4j:slf4j-api:1.7.25
org.typelevel:macro-compat_2.12:1.1.1
org.xerial.snappy:snappy-java:1.1.2.6
```

Standalone deps:
```
com.chuusai:shapeless_2.12:2.3.3
com.fasterxml.jackson.core:jackson-annotations:2.6.7
com.fasterxml.jackson.core:jackson-core:2.6.7
com.fasterxml.jackson.core:jackson-databind:2.6.7
com.fasterxml.jackson.module:jackson-module-paranamer:2.7.9
com.fasterxml.jackson.module:jackson-module-scala_2.12:2.6.7.1
com.github.mjakubowski84:parquet4s-core_2.12:1.2.1
com.thoughtworks.paranamer:paranamer:2.8
commons-codec:commons-codec:1.10
commons-pool:commons-pool:1.6
io.delta:standalone_2.12:0.2.0
org.apache.parquet:parquet-column:1.10.1
org.apache.parquet:parquet-common:1.10.1
org.apache.parquet:parquet-encoding:1.10.1
org.apache.parquet:parquet-format:2.4.0
org.apache.parquet:parquet-hadoop:1.10.1
org.apache.parquet:parquet-jackson:1.10.1
org.codehaus.jackson:jackson-core-asl:1.9.13
org.codehaus.jackson:jackson-mapper-asl:1.9.13
org.json4s:json4s-ast_2.12:3.5.3
org.json4s:json4s-core_2.12:3.5.3
org.json4s:json4s-jackson_2.12:3.5.3
org.json4s:json4s-scalap_2.12:3.5.3
org.scala-lang:scala-reflect:2.12.8
org.scala-lang.modules:scala-collection-compat_2.12:2.1.6
org.scala-lang.modules:scala-xml_2.12:1.0.6
org.slf4j:slf4j-api:1.7.25
org.typelevel:macro-compat_2.12:1.1.1
org.xerial.snappy:snappy-java:1.1.2.6
```

Hive 2.3.7 jars:
```
HikariCP-2.5.1.jar
RoaringBitmap-0.5.18.jar
ST4-4.0.4.jar
accumulo-core-1.6.0.jar
accumulo-fate-1.6.0.jar
accumulo-start-1.6.0.jar
accumulo-trace-1.6.0.jar
activation-1.1.jar
aether-api-0.9.0.M2.jar
aether-connector-file-0.9.0.M2.jar
aether-connector-okhttp-0.0.9.jar
aether-impl-0.9.0.M2.jar
aether-spi-0.9.0.M2.jar
aether-util-0.9.0.M2.jar
aircompressor-0.8.jar
airline-0.7.jar
ant-1.6.5.jar
ant-1.9.1.jar
ant-launcher-1.9.1.jar
antlr-runtime-3.5.2.jar
antlr4-runtime-4.5.jar
apache-curator-2.7.1.pom
asm-3.1.jar
asm-commons-3.1.jar
asm-tree-3.1.jar
avatica-1.8.0.jar
avatica-metrics-1.8.0.jar
avro-1.7.7.jar
bonecp-0.8.0.RELEASE.jar
bytebuffer-collections-0.2.5.jar
calcite-core-1.10.0.jar
calcite-druid-1.10.0.jar
calcite-linq4j-1.10.0.jar
classmate-1.0.0.jar
commons-cli-1.2.jar
commons-codec-1.4.jar
commons-collections-3.2.2.jar
commons-compiler-2.7.6.jar
commons-compress-1.9.jar
commons-dbcp-1.4.jar
commons-dbcp2-2.0.1.jar
commons-el-1.0.jar
commons-httpclient-3.0.1.jar
commons-io-2.4.jar
commons-lang-2.6.jar
commons-lang3-3.1.jar
commons-logging-1.2.jar
commons-math-2.2.jar
commons-math3-3.6.1.jar
commons-pool-1.5.4.jar
commons-pool2-2.2.jar
commons-vfs2-2.0.jar
compress-lzf-1.0.3.jar
config-magic-0.9.jar
curator-client-2.7.1.jar
curator-framework-2.7.1.jar
curator-recipes-2.7.1.jar
curator-x-discovery-2.11.0.jar
datanucleus-api-jdo-4.2.4.jar
datanucleus-core-4.1.17.jar
datanucleus-rdbms-4.1.19.jar
derby-10.10.2.0.jar
derbyclient-10.11.1.1.jar
derbynet-10.11.1.1.jar
disruptor-3.3.0.jar
dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
druid-api-0.9.2.jar
druid-common-0.9.2.jar
druid-console-0.0.2.jar
druid-hdfs-storage-0.9.2.jar
druid-processing-0.9.2.jar
druid-server-0.9.2.jar
eigenbase-properties-1.1.5.jar
emitter-0.3.6.jar
extendedset-1.3.10.jar
findbugs-annotations-1.3.9-1.jar
geoip2-0.4.0.jar
geronimo-annotation_1.0_spec-1.1.1.jar
geronimo-jaspic_1.0_spec-1.0.jar
geronimo-jta_1.1_spec-1.1.1.jar
google-http-client-jackson2-1.15.0-rc.jar
groovy-all-2.4.4.jar
gson-2.2.4.jar
guava-14.0.1.jar
guice-multibindings-4.1.0.jar
guice-servlet-4.1.0.jar
hbase-annotations-1.1.1.jar
hbase-client-1.1.1.jar
hbase-common-1.1.1-tests.jar
hbase-common-1.1.1.jar
hbase-hadoop-compat-1.1.1.jar
hbase-hadoop2-compat-1.1.1-tests.jar
hbase-hadoop2-compat-1.1.1.jar
hbase-prefix-tree-1.1.1.jar
hbase-procedure-1.1.1.jar
hbase-protocol-1.1.1.jar
hbase-server-1.1.1.jar
hibernate-validator-5.1.3.Final.jar
hive-accumulo-handler-2.3.7.jar
hive-beeline-2.3.7.jar
hive-cli-2.3.7.jar
hive-common-2.3.7.jar
hive-contrib-2.3.7.jar
hive-druid-handler-2.3.7.jar
hive-exec-2.3.7.jar
hive-hbase-handler-2.3.7.jar
hive-hcatalog-core-2.3.7.jar
hive-hcatalog-server-extensions-2.3.7.jar
hive-hplsql-2.3.7.jar
hive-jdbc-2.3.7.jar
hive-jdbc-handler-2.3.7.jar
hive-llap-client-2.3.7.jar
hive-llap-common-2.3.7-tests.jar
hive-llap-common-2.3.7.jar
hive-llap-ext-client-2.3.7.jar
hive-llap-server-2.3.7.jar
hive-llap-tez-2.3.7.jar
hive-metastore-2.3.7.jar
hive-serde-2.3.7.jar
hive-service-2.3.7.jar
hive-service-rpc-2.3.7.jar
hive-shims-0.23-2.3.7.jar
hive-shims-2.3.7.jar
hive-shims-common-2.3.7.jar
hive-shims-scheduler-2.3.7.jar
hive-storage-api-2.4.0.jar
hive-testutils-2.3.7.jar
hive-vector-code-gen-2.3.7.jar
htrace-core-3.1.0-incubating.jar
http-client-1.0.4.jar
httpclient-4.4.jar
httpcore-4.4.jar
icu4j-4.8.1.jar
irc-api-1.0-0014.jar
ivy-2.4.0.jar
jackson-annotations-2.6.0.jar
jackson-core-2.6.5.jar
jackson-databind-2.6.5.jar
jackson-dataformat-smile-2.4.6.jar
jackson-datatype-guava-2.4.6.jar
jackson-datatype-joda-2.4.6.jar
jackson-jaxrs-1.9.13.jar
jackson-jaxrs-base-2.4.6.jar
jackson-jaxrs-json-provider-2.4.6.jar
jackson-jaxrs-smile-provider-2.4.6.jar
jackson-module-jaxb-annotations-2.4.6.jar
jackson-xc-1.9.13.jar
jamon-runtime-2.3.1.jar
janino-2.7.6.jar
jasper-compiler-5.5.23.jar
jasper-runtime-5.5.23.jar
java-util-0.27.10.jar
javax.el-3.0.0.jar
javax.el-api-3.0.0.jar
javax.inject-1.jar
javax.jdo-3.2.0-m3.jar
javax.servlet-3.0.0.v201112011016.jar
javax.servlet-api-3.1.0.jar
javolution-5.5.1.jar
jboss-logging-3.1.3.GA.jar
jcodings-1.0.8.jar
jcommander-1.32.jar
jdbi-2.63.1.jar
jdo-api-3.0.1.jar
jersey-client-1.9.jar
jersey-guice-1.19.jar
jersey-server-1.14.jar
jettison-1.1.jar
jetty-6.1.26.jar
jetty-all-7.6.0.v20120127.jar
jetty-client-9.2.5.v20141112.jar
jetty-continuation-9.2.5.v20141112.jar
jetty-http-9.2.5.v20141112.jar
jetty-io-9.2.5.v20141112.jar
jetty-proxy-9.2.5.v20141112.jar
jetty-security-9.2.5.v20141112.jar
jetty-server-9.2.5.v20141112.jar
jetty-servlet-9.2.5.v20141112.jar
jetty-servlets-9.2.5.v20141112.jar
jetty-sslengine-6.1.26.jar
jetty-util-6.1.26.jar
jetty-util-9.2.5.v20141112.jar
jline-2.12.jar
joda-time-2.8.1.jar
jol-core-0.2.jar
joni-2.1.2.jar
jpam-1.1.jar
json-1.8.jar
json-path-2.1.0.jar
jsp-2.1-6.1.14.jar
jsp-api-2.0.jar
jsp-api-2.1-6.1.14.jar
jsp-api-2.1.jar
jsr305-3.0.0.jar
jta-1.1.jar
libfb303-0.9.3.jar
libthrift-0.9.3.jar
log4j-1.2-api-2.6.2.jar
log4j-api-2.6.2.jar
log4j-core-2.6.2.jar
log4j-jul-2.5.jar
log4j-slf4j-impl-2.6.2.jar
log4j-web-2.6.2.jar
lz4-1.3.0.jar
mail-1.4.1.jar
mapdb-1.0.8.jar
maven-aether-provider-3.1.1.jar
maven-model-3.1.1.jar
maven-model-builder-3.1.1.jar
maven-repository-metadata-3.1.1.jar
maven-scm-api-1.4.jar
maven-scm-provider-svn-commons-1.4.jar
maven-scm-provider-svnexe-1.4.jar
maven-settings-3.1.1.jar
maven-settings-builder-3.1.1.jar
maxminddb-0.2.0.jar
metrics-core-2.2.0.jar
metrics-core-3.1.0.jar
metrics-json-3.1.0.jar
metrics-jvm-3.1.0.jar
mysql-metadata-storage-0.9.2.jar
netty-3.6.2.Final.jar
netty-all-4.0.52.Final.jar
okhttp-1.0.2.jar
opencsv-2.3.jar
orc-core-1.3.4.jar
org.abego.treelayout.core-1.0.1.jar
paranamer-2.3.jar
parquet-hadoop-bundle-1.8.1.jar
pentaho-aggdesigner-algorithm-5.1.5-jhyde.jar
php
plexus-interpolation-1.19.jar
plexus-utils-3.0.15.jar
postgresql-9.4.1208.jre7.jar
postgresql-metadata-storage-0.9.2.jar
protobuf-java-2.5.0.jar
py
regexp-1.3.jar
rhino-1.7R5.jar
server-metrics-0.2.8.jar
servlet-api-2.4.jar
servlet-api-2.5-6.1.14.jar
slice-0.29.jar
slider-core-0.90.2-incubating.jar
snappy-java-1.0.5.jar
spymemcached-2.11.7.jar
stax-api-1.0.1.jar
super-csv-2.2.0.jar
tempus-fugit-1.1.jar
tesla-aether-0.0.5.jar
transaction-api-1.1.jar
validation-api-1.1.0.Final.jar
velocity-1.5.jar
wagon-provider-api-2.4.jar
zookeeper-3.4.6.jar
```